### PR TITLE
Add workable authentication for navigation endpoint for web mode

### DIFF
--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -88,7 +88,8 @@ func TestSetup(t *testing.T) {
 
 			mockedDataStore := &storetest.StorerMock{}
 
-			Convey("And when permission auth is enabled", func() {
+			Convey("And when the app auth token is not set", func() {
+				cfg.AppAuthToken = ""
 				cfg.EnablePermissionsAuth = true
 				api := GetWebAPIWithMocks(testContext, cfg, mockedDataStore, permissions)
 
@@ -98,12 +99,12 @@ func TestSetup(t *testing.T) {
 					So(hasRoute(api.Router, "/topics/{id}", "GET"), ShouldBeTrue)
 					So(hasRoute(api.Router, "/topics/{id}/subtopics", "GET"), ShouldBeTrue)
 					So(hasRoute(api.Router, "/topics/{id}/content", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeTrue)
+					So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeFalse)
 				})
 			})
 
-			Convey("and when permission auth not enabled", func() {
-				cfg.EnablePermissionsAuth = false
+			Convey("and when app auth token is set", func() {
+				cfg.AppAuthToken = "4946B8C8-77F7-47E2-BABA-B71E0B264A93"
 				api := GetWebAPIWithMocks(testContext, cfg, mockedDataStore, permissions)
 
 				Convey("Then the following routes should have been added", func() {
@@ -112,7 +113,7 @@ func TestSetup(t *testing.T) {
 					So(hasRoute(api.Router, "/topics/{id}", "GET"), ShouldBeTrue)
 					So(hasRoute(api.Router, "/topics/{id}/subtopics", "GET"), ShouldBeTrue)
 					So(hasRoute(api.Router, "/topics/{id}/content", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeFalse)
+					So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeTrue)
 				})
 			})
 		})

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ type MongoConfig = mongodb.MongoDriverConfig
 
 // Config represents service config for dp-topic-api
 type Config struct {
+	AppAuthToken               string        `envconfig:"APP_AUTH_TOKEN"                 json:"-"`
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
@@ -37,6 +38,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg = &Config{
+		AppAuthToken:               "",
 		BindAddr:                   "localhost:25300",
 		GracefulShutdownTimeout:    10 * time.Second,
 		HealthCheckInterval:        30 * time.Second,


### PR DESCRIPTION
### What

Instead of using Zebedee CMS which does not run in web mode, use configured
app auth token instead

### How to review

Check changes make sense
Check authentication of public nav endpoint works:

1. Update configured `AppAuthToken` to something other than empty string (as the app will not create navigation route to prevents app being shipped with no way to authenticate requests)
2. Update configured `EnablePrivateEndpoints` to false as we are testing public endpoint
3. Make request to `/navigation` endpoint with Authorization header set to your `AppAuthToken` value set in 1, something like:
  `curl localhost:25300/navigation -H "Authorization:Bearer <AppAuthToken>" |  jq` <- should return english version of navigation data
4. Test welsh:
  `curl "localhost:25300/navigation?lang=cy" -H "Authorization:Bearer <AppAuthToken>" |  jq`

### Who can review

Anyone
