### PR TITLE
Remove authentication of navigation endpoint for public endpoints (we…

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -59,10 +59,6 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, dataStor
 
 		log.Info(ctx, "enabling only public endpoints for dataset api")
 		api.enablePublicEndpoints(ctx)
-
-		if cfg.EnablePermissionsAuth {
-			api.enablePublicEndpointsWithAuth(ctx)
-		}
 	}
 
 	return api
@@ -70,19 +66,11 @@ func Setup(ctx context.Context, cfg *config.Config, router *mux.Router, dataStor
 
 // enablePublicEndpoints register only the public GET endpoints.
 func (api *API) enablePublicEndpoints(ctx context.Context) {
+	api.get("/topics", api.getTopicsListPublicHandler)
 	api.get("/topics/{id}", api.getTopicPublicHandler)
 	api.get("/topics/{id}/subtopics", api.getSubtopicsPublicHandler)
 	api.get("/topics/{id}/content", api.getContentPublicHandler)
-	api.get("/topics", api.getTopicsListPublicHandler)
-}
-
-func (api *API) enablePublicEndpointsWithAuth(ctx context.Context) {
-	// api.get("/navigation", api.getNavigationPrivateHandler)
-	api.get(
-		"/navigation",
-		api.isAuthenticated(
-			api.isAuthorised(readPermission, api.getNavigationPrivateHandler)),
-	)
+	api.get("/navigation", api.getNavigationPrivateHandler)
 }
 
 // enablePrivateTopicEndpoints register the topics endpoints with the appropriate authentication and authorisation

--- a/api/webendpoints_test.go
+++ b/api/webendpoints_test.go
@@ -32,7 +32,7 @@ func TestPublishedSubnetEndpointsAreDisabled(t *testing.T) {
 
 	publishSubnetEndpoints := map[testEndpoint]int{
 		// Topics endpoints
-		{Method: "GET", URL: "http://localhost:25300/navigation"}: http.StatusNotFound,
+		{Method: "GET", URL: "http://localhost:25300/bad-endpoint"}: http.StatusNotFound,
 	}
 
 	Convey("When the API is started with private endpoints disabled and permission auth disabled", t, func() {
@@ -85,35 +85,19 @@ func TestSetup(t *testing.T) {
 			cfg, err := config.Get()
 			So(err, ShouldBeNil)
 			cfg.EnablePrivateEndpoints = false
+			cfg.EnablePermissionsAuth = true
 
 			mockedDataStore := &storetest.StorerMock{}
 
-			Convey("And when permission auth is enabled", func() {
-				cfg.EnablePermissionsAuth = true
-				api := GetWebAPIWithMocks(testContext, cfg, mockedDataStore, permissions)
+			api := GetWebAPIWithMocks(testContext, cfg, mockedDataStore, permissions)
 
-				Convey("Then the following routes should have been added", func() {
-					So(api, ShouldNotBeNil)
-					So(hasRoute(api.Router, "/topics", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/topics/{id}", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/topics/{id}/subtopics", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/topics/{id}/content", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeTrue)
-				})
-			})
-
-			Convey("and when permission auth not enabled", func() {
-				cfg.EnablePermissionsAuth = false
-				api := GetWebAPIWithMocks(testContext, cfg, mockedDataStore, permissions)
-
-				Convey("Then the following routes should have been added", func() {
-					So(api, ShouldNotBeNil)
-					So(hasRoute(api.Router, "/topics", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/topics/{id}", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/topics/{id}/subtopics", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/topics/{id}/content", "GET"), ShouldBeTrue)
-					So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeFalse)
-				})
+			Convey("Then the following routes should have been added", func() {
+				So(api, ShouldNotBeNil)
+				So(hasRoute(api.Router, "/topics", "GET"), ShouldBeTrue)
+				So(hasRoute(api.Router, "/topics/{id}", "GET"), ShouldBeTrue)
+				So(hasRoute(api.Router, "/topics/{id}/subtopics", "GET"), ShouldBeTrue)
+				So(hasRoute(api.Router, "/topics/{id}/content", "GET"), ShouldBeTrue)
+				So(hasRoute(api.Router, "/navigation", "GET"), ShouldBeTrue)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Remove authentication of navigation endpoint for public endpoints (web mode)

### How to review

Check you can call `/navigation` endpoint without any authenticating headers are set: `curl localhost:25300/navigation` and for welsh `curl localhost:25300/navigation?lang=cy`

### Who can review

Anyone
