### PR TITLE
Allow for more time to pass in service test between calling shutdown and...

### DIFF
--- a/service/service_test.go
+++ b/service/service_test.go
@@ -346,7 +346,7 @@ func TestClose(t *testing.T) {
 			timeoutServerMock := &mock.HTTPServerMock{
 				ListenAndServeFunc: func() error { return nil },
 				ShutdownFunc: func(ctx context.Context) error {
-					time.Sleep(2 * time.Millisecond)
+					time.Sleep(5 * time.Millisecond)
 					return nil
 				},
 			}


### PR DESCRIPTION
### What

To prevent intermittent unit test failure!

...the service to be able to close all connections. This will enforce a forced
shutdown due to graceful shutdown timeout exceeding deadline needed for test.

Previously the shutdown would be graceful and other times not, this was solely to
do with the timeouts being too close to one another resulting in different outcomes
when running the unit test.

### How to review

Check changes make sense

### Who can review

Anyone
