### PR TITLE
add `GetSubtopics` client func for web and publishing

### DIFF
--- a/api/topic_private_test.go
+++ b/api/topic_private_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestGetTopicPrivateHandler(t *testing.T) {
-	t.Parallel()
-
 	Convey("Given a topic API in publishing mode (private endpoints enabled)", t, func() {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
@@ -68,8 +66,6 @@ func TestGetTopicPrivateHandler(t *testing.T) {
 }
 
 func TestGetSubtopicsPrivateHandler(t *testing.T) {
-	t.Parallel()
-
 	Convey("Given a topic API in web mode (private endpoints enabled)", t, func() {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)
@@ -202,8 +198,6 @@ func TestGetSubtopicsPrivateHandler(t *testing.T) {
 }
 
 func TestGetTopicsListPrivateHandler(t *testing.T) {
-	t.Parallel()
-
 	Convey("Given a topic API in web mode (private endpoints enabled)", t, func() {
 		cfg, err := config.Get()
 		So(err, ShouldBeNil)

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -87,6 +87,35 @@ func (cli *Client) GetRootTopicsPublic(ctx context.Context, reqHeaders Headers) 
 	return &rootTopics, nil
 }
 
+// GetSubtopicsPublic gets the public list of subtopics of a topic for Web which returns the Current document(s) in the response
+func (cli *Client) GetSubtopicsPublic(ctx context.Context, reqHeaders Headers, id string) (*models.PublicSubtopics, error) {
+	path := fmt.Sprintf("%s/topics/%s/subtopics", cli.hcCli.URL, id)
+
+	b, err := cli.callTopicAPI(ctx, path, http.MethodGet, reqHeaders, nil)
+	if err != nil {
+		logData := log.Data{
+			"path":        path,
+			"method":      http.MethodGet,
+			"req_headers": reqHeaders,
+			"body":        nil,
+		}
+		log.Error(ctx, "failed to call topic api", err, logData)
+		return nil, err
+	}
+
+	var subtopics models.PublicSubtopics
+
+	if err = json.Unmarshal(b, &subtopics); err != nil {
+		logData := log.Data{
+			"response_bytes": b,
+		}
+		log.Error(ctx, "failed to unmarshal bytes into subtopics", err, logData)
+		return nil, err
+	}
+
+	return &subtopics, nil
+}
+
 // callTopicAPI calls the Topic API endpoint given by path for the provided REST method, request headers, and body payload.
 // It returns the response body and any error that occurred.
 func (cli *Client) callTopicAPI(ctx context.Context, path, method string, headers Headers, payload []byte) ([]byte, error) {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -34,13 +33,10 @@ func New(topicAPIURL string) *Client {
 
 // NewWithHealthClient creates a new instance of topic API Client,
 // reusing the URL and Clienter from the provided healthcheck client
-func NewWithHealthClient(hcCli *healthcheck.Client) (*Client, error) {
-	if hcCli == nil {
-		return nil, errors.New("health client is nil")
-	}
+func NewWithHealthClient(hcCli *healthcheck.Client) *Client {
 	return &Client{
 		hcCli: healthcheck.NewClientWithClienter(service, hcCli.URL, hcCli.Client),
-	}, nil
+	}
 }
 
 // URL returns the URL used by this client

--- a/sdk/client_private.go
+++ b/sdk/client_private.go
@@ -38,3 +38,32 @@ func (cli *Client) GetRootTopicsPrivate(ctx context.Context, reqHeaders Headers)
 
 	return &rootTopics, nil
 }
+
+// GetSubtopicsPrivate gets the private list of subtopics of a topic for Publishing which returns both Next and Current document(s) in the response
+func (cli *Client) GetSubtopicsPrivate(ctx context.Context, reqHeaders Headers, id string) (*models.PrivateSubtopics, error) {
+	path := fmt.Sprintf("%s/topics/%s/subtopics", cli.hcCli.URL, id)
+
+	b, err := cli.callTopicAPI(ctx, path, http.MethodGet, reqHeaders, nil)
+	if err != nil {
+		logData := log.Data{
+			"path":        path,
+			"method":      http.MethodGet,
+			"req_headers": reqHeaders,
+			"body":        nil,
+		}
+		log.Error(ctx, "failed to call topic api", err, logData)
+		return nil, err
+	}
+
+	var subtopics models.PrivateSubtopics
+
+	if err = json.Unmarshal(b, &subtopics); err != nil {
+		logData := log.Data{
+			"response_bytes": b,
+		}
+		log.Error(ctx, "failed to unmarshal bytes into subtopics", err, logData)
+		return nil, err
+	}
+
+	return &subtopics, nil
+}

--- a/sdk/client_private_test.go
+++ b/sdk/client_private_test.go
@@ -15,24 +15,24 @@ import (
 )
 
 var (
-	testPrivateRootTopics = models.PrivateSubtopics{
+	testPrivateTopics = models.PrivateSubtopics{
 		Count:        2,
 		Offset:       0,
 		Limit:        100,
 		TotalCount:   2,
-		PrivateItems: &[]models.TopicResponse{testPrivateRootTopic1, testPrivateRootTopic2},
+		PrivateItems: &[]models.TopicResponse{testPrivateTopic1, testPrivateTopic2},
 	}
 
-	testPrivateRootTopic1 = models.TopicResponse{
+	testPrivateTopic1 = models.TopicResponse{
 		ID:      "1234",
-		Current: &testPublicRootTopic1,
-		Next:    &testPublicRootTopic1,
+		Current: &testPublicTopic1,
+		Next:    &testPublicTopic1,
 	}
 
-	testPrivateRootTopic2 = models.TopicResponse{
+	testPrivateTopic2 = models.TopicResponse{
 		ID:      "5678",
-		Current: &testPublicRootTopic2,
-		Next:    &testPublicRootTopic2,
+		Current: &testPublicTopic2,
+		Next:    &testPublicTopic2,
 	}
 )
 
@@ -41,7 +41,7 @@ func TestGetRootTopicsPrivate(t *testing.T) {
 	ctx := context.Background()
 
 	Convey("Given the private root topics is returned successfully", t, func() {
-		body, err := json.Marshal(testPrivateRootTopics)
+		body, err := json.Marshal(testPrivateTopics)
 		if err != nil {
 			t.Errorf("failed to setup test data, error: %v", err)
 		}
@@ -61,7 +61,7 @@ func TestGetRootTopicsPrivate(t *testing.T) {
 			})
 
 			Convey("Then the expected private root topics is returned", func() {
-				So(*respRootTopics, ShouldResemble, testPrivateRootTopics)
+				So(*respRootTopics, ShouldResemble, testPrivateTopics)
 
 				Convey("And no error is returned", func() {
 					So(err, ShouldBeNil)
@@ -118,6 +118,95 @@ func TestGetRootTopicsPrivate(t *testing.T) {
 						doCalls := httpClient.DoCalls()
 						So(doCalls, ShouldHaveLength, 1)
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics")
+					})
+				})
+			})
+		})
+	})
+}
+
+func TestGetSubtopicsPrivate(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	Convey("Given private subtopics is returned successfully", t, func() {
+		body, err := json.Marshal(testPrivateTopics)
+		if err != nil {
+			t.Errorf("failed to setup test data, error: %v", err)
+		}
+
+		httpClient := newMockHTTPClient(
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			},
+			nil)
+
+		topicAPIClient := newTopicAPIClient(t, httpClient)
+
+		Convey("When GetSubtopicsPrivate is called", func() {
+			respSubtopics, err := topicAPIClient.GetSubtopicsPrivate(ctx, Headers{
+				ServiceAuthToken: "valid-service-token",
+			}, "1357")
+
+			Convey("Then the expected private subtopics is returned", func() {
+				So(*respSubtopics, ShouldResemble, testPrivateTopics)
+
+				Convey("And no error is returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And client.Do should be called once with the expected parameters", func() {
+						doCalls := httpClient.DoCalls()
+						So(doCalls, ShouldHaveLength, 1)
+						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics/1357/subtopics")
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given a 500 response from topic api", t, func() {
+		httpClient := newMockHTTPClient(&http.Response{StatusCode: http.StatusInternalServerError}, nil)
+		topicAPIClient := newTopicAPIClient(t, httpClient)
+
+		Convey("When GetSubtopicsPrivate is called", func() {
+			respSubtopics, err := topicAPIClient.GetSubtopicsPrivate(ctx, Headers{}, "1357")
+
+			Convey("Then an error should be returned ", func() {
+				So(err, ShouldNotBeNil)
+
+				Convey("And the expected private subtopics should be nil", func() {
+					So(respSubtopics, ShouldBeNil)
+
+					Convey("And client.Do should be called once with the expected parameters", func() {
+						doCalls := httpClient.DoCalls()
+						So(doCalls, ShouldHaveLength, 1)
+						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics/1357/subtopics")
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given the client returns an unexpected error", t, func() {
+		clientError := errors.New("unexpected error")
+		httpClient := newMockHTTPClient(&http.Response{}, clientError)
+
+		topicAPIClient := newTopicAPIClient(t, httpClient)
+
+		Convey("When GetSubtopicsPrivate is called", func() {
+			respSubtopics, err := topicAPIClient.GetSubtopicsPrivate(ctx, Headers{}, "1357")
+
+			Convey("Then an error should be returned ", func() {
+				So(err, ShouldNotBeNil)
+
+				Convey("And the expected private subtopics should be nil", func() {
+					So(respSubtopics, ShouldBeNil)
+
+					Convey("And client.Do should be called once with the expected parameters", func() {
+						doCalls := httpClient.DoCalls()
+						So(doCalls, ShouldHaveLength, 1)
+						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics/1357/subtopics")
 					})
 				})
 			})

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -66,12 +66,7 @@ func newMockHTTPClient(r *http.Response, err error) *dphttp.ClienterMock {
 
 func newTopicAPIClient(t *testing.T, httpClient *dphttp.ClienterMock) *Client {
 	healthClient := healthcheck.NewClientWithClienter(service, testHost, httpClient)
-	searchReindexClient, err := NewWithHealthClient(healthClient)
-	if err != nil {
-		t.Errorf("failed to create a topic api client, error is: %v", err)
-	}
-
-	return searchReindexClient
+	return NewWithHealthClient(healthClient)
 }
 
 func TestHealthCheckerClient(t *testing.T) {

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -26,15 +26,15 @@ const (
 var (
 	initialTestState = healthcheck.CreateCheckState(service)
 
-	testPublicRootTopics = models.PublicSubtopics{
+	testPublicTopics = models.PublicSubtopics{
 		Count:       2,
 		Offset:      0,
 		Limit:       100,
 		TotalCount:  2,
-		PublicItems: &[]models.Topic{testPublicRootTopic1, testPublicRootTopic2},
+		PublicItems: &[]models.Topic{testPublicTopic1, testPublicTopic2},
 	}
 
-	testPublicRootTopic1 = models.Topic{
+	testPublicTopic1 = models.Topic{
 		ID:          "1234",
 		Description: "Root Topic 1",
 		Title:       "Root Topic 1",
@@ -42,7 +42,7 @@ var (
 		State:       "published",
 	}
 
-	testPublicRootTopic2 = models.Topic{
+	testPublicTopic2 = models.Topic{
 		ID:          "5678",
 		Description: "Root Topic 2",
 		Title:       "Root Topic 2",
@@ -143,7 +143,7 @@ func TestGetRootTopicsPublic(t *testing.T) {
 	ctx := context.Background()
 
 	Convey("Given public root topics is returned successfully", t, func() {
-		body, err := json.Marshal(testPublicRootTopics)
+		body, err := json.Marshal(testPublicTopics)
 		if err != nil {
 			t.Errorf("failed to setup test data, error: %v", err)
 		}
@@ -161,7 +161,7 @@ func TestGetRootTopicsPublic(t *testing.T) {
 			respRootTopics, err := topicAPIClient.GetRootTopicsPublic(ctx, Headers{})
 
 			Convey("Then the expected public root topics is returned", func() {
-				So(*respRootTopics, ShouldResemble, testPublicRootTopics)
+				So(*respRootTopics, ShouldResemble, testPublicTopics)
 
 				Convey("And no error is returned", func() {
 					So(err, ShouldBeNil)
@@ -218,6 +218,93 @@ func TestGetRootTopicsPublic(t *testing.T) {
 						doCalls := httpClient.DoCalls()
 						So(doCalls, ShouldHaveLength, 1)
 						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics")
+					})
+				})
+			})
+		})
+	})
+}
+
+func TestGetSubtopicsPublic(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	Convey("Given public subtopics is returned successfully", t, func() {
+		body, err := json.Marshal(testPublicTopics)
+		if err != nil {
+			t.Errorf("failed to setup test data, error: %v", err)
+		}
+
+		httpClient := newMockHTTPClient(
+			&http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+			},
+			nil)
+
+		topicAPIClient := newTopicAPIClient(t, httpClient)
+
+		Convey("When GetSubtopicsPublic is called", func() {
+			respSubtopics, err := topicAPIClient.GetSubtopicsPublic(ctx, Headers{}, "1357")
+
+			Convey("Then the expected public subtopics is returned", func() {
+				So(*respSubtopics, ShouldResemble, testPublicTopics)
+
+				Convey("And no error is returned", func() {
+					So(err, ShouldBeNil)
+
+					Convey("And client.Do should be called once with the expected parameters", func() {
+						doCalls := httpClient.DoCalls()
+						So(doCalls, ShouldHaveLength, 1)
+						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics/1357/subtopics")
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given a 500 response from topic api", t, func() {
+		httpClient := newMockHTTPClient(&http.Response{StatusCode: http.StatusInternalServerError}, nil)
+		topicAPIClient := newTopicAPIClient(t, httpClient)
+
+		Convey("When GetSubtopicsPublic is called", func() {
+			respSubtopics, err := topicAPIClient.GetSubtopicsPublic(ctx, Headers{}, "1357")
+
+			Convey("Then an error should be returned ", func() {
+				So(err, ShouldNotBeNil)
+
+				Convey("And the expected public subtopics should be nil", func() {
+					So(respSubtopics, ShouldBeNil)
+
+					Convey("And client.Do should be called once with the expected parameters", func() {
+						doCalls := httpClient.DoCalls()
+						So(doCalls, ShouldHaveLength, 1)
+						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics/1357/subtopics")
+					})
+				})
+			})
+		})
+	})
+
+	Convey("Given the client returns an unexpected error", t, func() {
+		clientError := errors.New("unexpected error")
+		httpClient := newMockHTTPClient(&http.Response{}, clientError)
+
+		topicAPIClient := newTopicAPIClient(t, httpClient)
+
+		Convey("When GetSubtopicsPublic is called", func() {
+			respSubtopics, err := topicAPIClient.GetSubtopicsPublic(ctx, Headers{}, "1357")
+
+			Convey("Then an error should be returned ", func() {
+				So(err, ShouldNotBeNil)
+
+				Convey("And the expected public subtopics should be nil", func() {
+					So(respSubtopics, ShouldBeNil)
+
+					Convey("And client.Do should be called once with the expected parameters", func() {
+						doCalls := httpClient.DoCalls()
+						So(doCalls, ShouldHaveLength, 1)
+						So(doCalls[0].Req.URL.Path, ShouldEqual, "/topics/1357/subtopics")
 					})
 				})
 			})

--- a/sdk/interface.go
+++ b/sdk/interface.go
@@ -14,6 +14,8 @@ type Clienter interface {
 	Checker(ctx context.Context, check *health.CheckState) error
 	GetRootTopicsPrivate(ctx context.Context, reqHeaders Headers) (*models.PrivateSubtopics, error)
 	GetRootTopicsPublic(ctx context.Context, reqHeaders Headers) (*models.PublicSubtopics, error)
+	GetSubtopicsPrivate(ctx context.Context, reqHeaders Headers, id string) (*models.PrivateSubtopics, error)
+	GetSubtopicsPublic(ctx context.Context, reqHeaders Headers, id string) (*models.PublicSubtopics, error)
 	Health() *healthcheck.Client
 	URL() string
 }

--- a/sdk/mocks/client.go
+++ b/sdk/mocks/client.go
@@ -31,6 +31,12 @@ var _ sdk.Clienter = &ClienterMock{}
 // 			GetRootTopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers) (*models.PublicSubtopics, error) {
 // 				panic("mock out the GetRootTopicsPublic method")
 // 			},
+// 			GetSubtopicsPrivateFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, error) {
+// 				panic("mock out the GetSubtopicsPrivate method")
+// 			},
+// 			GetSubtopicsPublicFunc: func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, error) {
+// 				panic("mock out the GetSubtopicsPublic method")
+// 			},
 // 			HealthFunc: func() *healthcheck.Client {
 // 				panic("mock out the Health method")
 // 			},
@@ -52,6 +58,12 @@ type ClienterMock struct {
 
 	// GetRootTopicsPublicFunc mocks the GetRootTopicsPublic method.
 	GetRootTopicsPublicFunc func(ctx context.Context, reqHeaders sdk.Headers) (*models.PublicSubtopics, error)
+
+	// GetSubtopicsPrivateFunc mocks the GetSubtopicsPrivate method.
+	GetSubtopicsPrivateFunc func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, error)
+
+	// GetSubtopicsPublicFunc mocks the GetSubtopicsPublic method.
+	GetSubtopicsPublicFunc func(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, error)
 
 	// HealthFunc mocks the Health method.
 	HealthFunc func() *healthcheck.Client
@@ -82,6 +94,24 @@ type ClienterMock struct {
 			// ReqHeaders is the reqHeaders argument value.
 			ReqHeaders sdk.Headers
 		}
+		// GetSubtopicsPrivate holds details about calls to the GetSubtopicsPrivate method.
+		GetSubtopicsPrivate []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
+			// ID is the id argument value.
+			ID string
+		}
+		// GetSubtopicsPublic holds details about calls to the GetSubtopicsPublic method.
+		GetSubtopicsPublic []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ReqHeaders is the reqHeaders argument value.
+			ReqHeaders sdk.Headers
+			// ID is the id argument value.
+			ID string
+		}
 		// Health holds details about calls to the Health method.
 		Health []struct {
 		}
@@ -92,6 +122,8 @@ type ClienterMock struct {
 	lockChecker              sync.RWMutex
 	lockGetRootTopicsPrivate sync.RWMutex
 	lockGetRootTopicsPublic  sync.RWMutex
+	lockGetSubtopicsPrivate  sync.RWMutex
+	lockGetSubtopicsPublic   sync.RWMutex
 	lockHealth               sync.RWMutex
 	lockURL                  sync.RWMutex
 }
@@ -198,6 +230,84 @@ func (mock *ClienterMock) GetRootTopicsPublicCalls() []struct {
 	mock.lockGetRootTopicsPublic.RLock()
 	calls = mock.calls.GetRootTopicsPublic
 	mock.lockGetRootTopicsPublic.RUnlock()
+	return calls
+}
+
+// GetSubtopicsPrivate calls GetSubtopicsPrivateFunc.
+func (mock *ClienterMock) GetSubtopicsPrivate(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PrivateSubtopics, error) {
+	if mock.GetSubtopicsPrivateFunc == nil {
+		panic("ClienterMock.GetSubtopicsPrivateFunc: method is nil but Clienter.GetSubtopicsPrivate was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		ID         string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		ID:         id,
+	}
+	mock.lockGetSubtopicsPrivate.Lock()
+	mock.calls.GetSubtopicsPrivate = append(mock.calls.GetSubtopicsPrivate, callInfo)
+	mock.lockGetSubtopicsPrivate.Unlock()
+	return mock.GetSubtopicsPrivateFunc(ctx, reqHeaders, id)
+}
+
+// GetSubtopicsPrivateCalls gets all the calls that were made to GetSubtopicsPrivate.
+// Check the length with:
+//     len(mockedClienter.GetSubtopicsPrivateCalls())
+func (mock *ClienterMock) GetSubtopicsPrivateCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
+	ID         string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		ID         string
+	}
+	mock.lockGetSubtopicsPrivate.RLock()
+	calls = mock.calls.GetSubtopicsPrivate
+	mock.lockGetSubtopicsPrivate.RUnlock()
+	return calls
+}
+
+// GetSubtopicsPublic calls GetSubtopicsPublicFunc.
+func (mock *ClienterMock) GetSubtopicsPublic(ctx context.Context, reqHeaders sdk.Headers, id string) (*models.PublicSubtopics, error) {
+	if mock.GetSubtopicsPublicFunc == nil {
+		panic("ClienterMock.GetSubtopicsPublicFunc: method is nil but Clienter.GetSubtopicsPublic was just called")
+	}
+	callInfo := struct {
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		ID         string
+	}{
+		Ctx:        ctx,
+		ReqHeaders: reqHeaders,
+		ID:         id,
+	}
+	mock.lockGetSubtopicsPublic.Lock()
+	mock.calls.GetSubtopicsPublic = append(mock.calls.GetSubtopicsPublic, callInfo)
+	mock.lockGetSubtopicsPublic.Unlock()
+	return mock.GetSubtopicsPublicFunc(ctx, reqHeaders, id)
+}
+
+// GetSubtopicsPublicCalls gets all the calls that were made to GetSubtopicsPublic.
+// Check the length with:
+//     len(mockedClienter.GetSubtopicsPublicCalls())
+func (mock *ClienterMock) GetSubtopicsPublicCalls() []struct {
+	Ctx        context.Context
+	ReqHeaders sdk.Headers
+	ID         string
+} {
+	var calls []struct {
+		Ctx        context.Context
+		ReqHeaders sdk.Headers
+		ID         string
+	}
+	mock.lockGetSubtopicsPublic.RLock()
+	calls = mock.calls.GetSubtopicsPublic
+	mock.lockGetSubtopicsPublic.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- add `GetSubtopics` client func for web and publishing
- Remove `error` return on `NewWithHealthClient` so that it can easily be used in other apps. Also, the `if hcCli == nil` is not needed

### How to review
**Describe the steps required to test the changes.**
- Check if the code changes make sense
- Check if the tests passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone