### PR TITLE
update error handling for sdk package

### DIFF
--- a/sdk/client_private.go
+++ b/sdk/client_private.go
@@ -7,62 +7,46 @@ import (
 	"net/http"
 
 	"github.com/ONSdigital/dp-topic-api/models"
-	"github.com/ONSdigital/log.go/v2/log"
+	apiError "github.com/ONSdigital/dp-topic-api/sdk/errors"
 )
 
 // GetRootTopicsPrivate gets the private list of top level root topics for Publishing which returns both Next and Current document(s) in the response
-func (cli *Client) GetRootTopicsPrivate(ctx context.Context, reqHeaders Headers) (*models.PrivateSubtopics, error) {
+func (cli *Client) GetRootTopicsPrivate(ctx context.Context, reqHeaders Headers) (*models.PrivateSubtopics, apiError.Error) {
 	path := fmt.Sprintf("%s/topics", cli.hcCli.URL)
 
-	b, err := cli.callTopicAPI(ctx, path, http.MethodGet, reqHeaders, nil)
-	if err != nil {
-		logData := log.Data{
-			"path":        path,
-			"method":      http.MethodGet,
-			"req_headers": reqHeaders,
-			"body":        nil,
-		}
-		log.Error(ctx, "failed to call topic api", err, logData)
-		return nil, err
+	b, apiErr := cli.callTopicAPI(ctx, path, http.MethodGet, reqHeaders, nil)
+	if apiErr != nil {
+		return nil, apiErr
 	}
 
 	var rootTopics models.PrivateSubtopics
 
-	if err = json.Unmarshal(b, &rootTopics); err != nil {
-		logData := log.Data{
-			"response_bytes": b,
+	if err := json.Unmarshal(b, &rootTopics); err != nil {
+		return nil, apiError.StatusError{
+			Err:  fmt.Errorf("failed to unmarshal rootTopics - error is: %v", err),
+			Code: apiErr.Status(),
 		}
-		log.Error(ctx, "failed to unmarshal bytes into root topics", err, logData)
-		return nil, err
 	}
 
 	return &rootTopics, nil
 }
 
 // GetSubtopicsPrivate gets the private list of subtopics of a topic for Publishing which returns both Next and Current document(s) in the response
-func (cli *Client) GetSubtopicsPrivate(ctx context.Context, reqHeaders Headers, id string) (*models.PrivateSubtopics, error) {
+func (cli *Client) GetSubtopicsPrivate(ctx context.Context, reqHeaders Headers, id string) (*models.PrivateSubtopics, apiError.Error) {
 	path := fmt.Sprintf("%s/topics/%s/subtopics", cli.hcCli.URL, id)
 
-	b, err := cli.callTopicAPI(ctx, path, http.MethodGet, reqHeaders, nil)
-	if err != nil {
-		logData := log.Data{
-			"path":        path,
-			"method":      http.MethodGet,
-			"req_headers": reqHeaders,
-			"body":        nil,
-		}
-		log.Error(ctx, "failed to call topic api", err, logData)
-		return nil, err
+	b, apiErr := cli.callTopicAPI(ctx, path, http.MethodGet, reqHeaders, nil)
+	if apiErr != nil {
+		return nil, apiErr
 	}
 
 	var subtopics models.PrivateSubtopics
 
-	if err = json.Unmarshal(b, &subtopics); err != nil {
-		logData := log.Data{
-			"response_bytes": b,
+	if err := json.Unmarshal(b, &subtopics); err != nil {
+		return nil, apiError.StatusError{
+			Err:  fmt.Errorf("failed to unmarshal subtopics - error is: %v", err),
+			Code: apiErr.Status(),
 		}
-		log.Error(ctx, "failed to unmarshal bytes into subtopics", err, logData)
-		return nil, err
 	}
 
 	return &subtopics, nil

--- a/sdk/client_private_test.go
+++ b/sdk/client_private_test.go
@@ -85,6 +85,7 @@ func TestGetRootTopicsPrivate(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected private root topics should be nil", func() {
 					So(respRootTopics, ShouldBeNil)
@@ -110,6 +111,7 @@ func TestGetRootTopicsPrivate(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected private root topics should be nil", func() {
 					So(respRootTopics, ShouldBeNil)
@@ -174,6 +176,7 @@ func TestGetSubtopicsPrivate(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected private subtopics should be nil", func() {
 					So(respSubtopics, ShouldBeNil)
@@ -199,6 +202,7 @@ func TestGetSubtopicsPrivate(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected private subtopics should be nil", func() {
 					So(respSubtopics, ShouldBeNil)

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -196,6 +196,7 @@ func TestGetRootTopicsPublic(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected public root topics should be nil", func() {
 					So(respRootTopics, ShouldBeNil)
@@ -221,6 +222,7 @@ func TestGetRootTopicsPublic(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected public root topics should be nil", func() {
 					So(respRootTopics, ShouldBeNil)
@@ -283,6 +285,7 @@ func TestGetSubtopicsPublic(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected public subtopics should be nil", func() {
 					So(respSubtopics, ShouldBeNil)
@@ -308,6 +311,7 @@ func TestGetSubtopicsPublic(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected public subtopics should be nil", func() {
 					So(respSubtopics, ShouldBeNil)
@@ -388,6 +392,7 @@ func TestGetNavigationPublic(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected public navigation items should be nil", func() {
 					So(respNavigation, ShouldBeNil)
@@ -413,6 +418,7 @@ func TestGetNavigationPublic(t *testing.T) {
 
 			Convey("Then an error should be returned ", func() {
 				So(err, ShouldNotBeNil)
+				So(err.Status(), ShouldEqual, http.StatusInternalServerError)
 
 				Convey("And the expected public subtopics should be nil", func() {
 					So(respNavigation, ShouldBeNil)


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Update the client functions (expect for `/health`) to return `apierrors.Error` (which also contains information on status code) instead of `errors` 
- Remove `log.Error` lines as the client functions should not depend on our log library and these functions are publicly available to use

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone