### PR TITLE
fix sdk error handling

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -66,8 +66,7 @@ func (cli *Client) GetRootTopicsPublic(ctx context.Context, reqHeaders Headers) 
 
 	if err := json.Unmarshal(b, &rootTopics); err != nil {
 		return nil, apiError.StatusError{
-			Err:  fmt.Errorf("failed to unmarshal rootTopics - error is: %v", err),
-			Code: apiErr.Status(),
+			Err: fmt.Errorf("failed to unmarshal rootTopics - error is: %v", err),
 		}
 	}
 
@@ -87,8 +86,7 @@ func (cli *Client) GetSubtopicsPublic(ctx context.Context, reqHeaders Headers, i
 
 	if err := json.Unmarshal(b, &subtopics); err != nil {
 		return nil, apiError.StatusError{
-			Err:  fmt.Errorf("failed to unmarshal subtopics - error is: %v", err),
-			Code: apiErr.Status(),
+			Err: fmt.Errorf("failed to unmarshal subtopics - error is: %v", err),
 		}
 	}
 
@@ -115,8 +113,7 @@ func (cli *Client) GetNavigationPublic(ctx context.Context, reqHeaders Headers, 
 
 	if err = json.Unmarshal(b, &navigation); err != nil {
 		return nil, apiError.StatusError{
-			Err:  fmt.Errorf("failed to unmarshal navigation - error is: %v", err),
-			Code: apiErr.Status(),
+			Err: fmt.Errorf("failed to unmarshal navigation - error is: %v", err),
 		}
 	}
 

--- a/sdk/client_private.go
+++ b/sdk/client_private.go
@@ -23,8 +23,7 @@ func (cli *Client) GetRootTopicsPrivate(ctx context.Context, reqHeaders Headers)
 
 	if err := json.Unmarshal(b, &rootTopics); err != nil {
 		return nil, apiError.StatusError{
-			Err:  fmt.Errorf("failed to unmarshal rootTopics - error is: %v", err),
-			Code: apiErr.Status(),
+			Err: fmt.Errorf("failed to unmarshal rootTopics - error is: %v", err),
 		}
 	}
 
@@ -44,8 +43,7 @@ func (cli *Client) GetSubtopicsPrivate(ctx context.Context, reqHeaders Headers, 
 
 	if err := json.Unmarshal(b, &subtopics); err != nil {
 		return nil, apiError.StatusError{
-			Err:  fmt.Errorf("failed to unmarshal subtopics - error is: %v", err),
-			Code: apiErr.Status(),
+			Err: fmt.Errorf("failed to unmarshal subtopics - error is: %v", err),
 		}
 	}
 


### PR DESCRIPTION
### What
**Describe what you have changed and why.**
- Fix sdk error handling
- If the call of `callTopicAPI` was successful, then the call `Code: apiErr.Status()` afterwards will panic as `apiErr` was `nil` beforehand (specifically `deference nil pointer` error)
- Also, we don't need to get `apiErr.Status()` at the point where it has been removed (as we already know that the status will be a success code otherwise it would have errored beforehand)

### How to review
**Describe the steps required to test the changes.**
- Check if the changes make sense
- Check if the test passes

### Who can review
**Describe who worked on the changes, so that other people can review.**
- Anyone