### PR TITLE
Add /go to Dockerfile as safe directory for git

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,7 @@
 FROM golang:1.22-bullseye AS base
 
+RUN git config --global --add safe.directory /go
+
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
 RUN GOBIN=/bin go install github.com/cespare/reflex@v0.3.1


### PR DESCRIPTION
### What

Jira ticket: https://jira.ons.gov.uk/browse/DIS-1639

It was not possible to run the homepage web stack, using colima, due to a 'dubious ownership' error that was appearing in the docker logs for the topic api. This PR solves the problem.

### How to review

Run the search stack using colima, as follows:

- Move to homepage web stack directory
```shell
cd dp-compose/v2/stacks/homepage-web
```

- start colima, using enough memory for the stack NB. use `brew install colima' if it's not currently installed.
```shell
colima start --cpu 4 --memory 8 --disk 100
```

- bring up the homepage web stack (you may need to do 'make clean' first)
```shell
make up
```

- After some time check to see whether all the services are up and healthy
```shell
make health
```

You should see that all the services are healthy including the topic api.

- the following URL should now show the expected homepage:
http://localhost:20000/

### Who can review

Anyone but me.
