### PR TITLE
Add Dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The follow dependencies can all be met by running the Auth stack and then loggin
 * Mongo db
 * Florence authentication (AWS cognito)
 
-NB. Use [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/v2/stacks/auth) to run these services in docker containers; this requires Docker and Colima.
+NB. Use [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/v2/stacks/auth) to run these services in Docker containers.
 
 * Once you have a working mongo db instance, you will want to populate your database with topics - see `./scripts/README.md` for seeding scripts
 * No further dependencies other than those defined in `go.mod`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Enables greater flexibility in creating journeys through the website
 
 ### Dependencies
 
-* Mongo db (can use [dp-compose](https://github.com/ONSdigital/dp-compose) to stand up an instance in docker container, this requires docker)
+The follow dependencies can all be met by running the Auth stack and then logging into your local Florence using your sandbox Florence credentials:
+* Zebedee
+* Mongo db
+* Florence authentication (AWS cognito)
+
+NB. Use [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/v2/stacks/auth) to run these services in docker containers; this requires Docker and Colima.
+
 * Once you have a working mongo db instance, you will want to populate your database with topics - see `./scripts/README.md` for seeding scripts
 * No further dependencies other than those defined in `go.mod`
 
@@ -20,25 +26,25 @@ To run make validate-specification you require Node v20.x and to install @redocl
 
 ### Configuration
 
-| Environment variable         | Default                                           | Description
-| ---------------------------- |---------------------------------------------------| -----------
-| BIND_ADDR                    | :25300                                            | The host and port to bind to
-| GRACEFUL_SHUTDOWN_TIMEOUT    | 10s                                               | The graceful shutdown timeout in seconds (`time.Duration` format)
-| HEALTHCHECK_INTERVAL         | 30s                                               | Time between self-healthchecks (`time.Duration` format)
-| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                               | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format)
-| MONGODB_BIND_ADDR            | localhost:27017                                   | The MongoDB bind address
-| MONGODB_USERNAME             |                                                   | MongoDB Username
-| MONGODB_PASSWORD             |                                                   | MongoDB Password
-| MONGODB_DATABASE             | topics                                            | The MongoDB topics database
-| MONGODB_COLLECTIONS          | TopicsCollection:topics,ContentCollection:content | MongoDB collections
-| MONGODB_ENABLE_READ_CONCERN  | false                                             | Switch to use (or not) majority read concern
-| MONGODB_ENABLE_WRITE_CONCERN | true                                              | Switch to use (or not) majority write concern
-| MONGODB_CONNECT_TIMEOUT      | 5s                                                | The timeout when connecting to MongoDB (`time.Duration` format)
-| MONGODB_QUERY_TIMEOUT        | 15s                                               | The timeout for querying MongoDB (`time.Duration` format)
-| MONGODB_IS_SSL               | false                                             | Switch to use (or not) TLS when connecting to mongodb
-| ZEBEDEE_URL                  | http://localhost:8082                             | The URL to Zebedee (for authentication)
-| ENABLE_PRIVATE_ENDPOINTS     | false                                             | Enable private endpoints for the API
-| ENABLE_PERMISSIONS_AUTHZ     | false                                             | Enable/disable user/service permissions checking for private endpoints
+| Environment variable         | Default                                           | Description                                                                                                        |
+|------------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| BIND_ADDR                    | :25300                                            | The host and port to bind to                                                                                       |
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 10s                                               | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
+| HEALTHCHECK_INTERVAL         | 30s                                               | Time between self-healthchecks (`time.Duration` format)                                                            |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                                               | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
+| MONGODB_BIND_ADDR            | localhost:27017                                   | The MongoDB bind address                                                                                           |
+| MONGODB_USERNAME             |                                                   | MongoDB Username                                                                                                   |
+| MONGODB_PASSWORD             |                                                   | MongoDB Password                                                                                                   |
+| MONGODB_DATABASE             | topics                                            | The MongoDB topics database                                                                                        |
+| MONGODB_COLLECTIONS          | TopicsCollection:topics,ContentCollection:content | MongoDB collections                                                                                                |
+| MONGODB_ENABLE_READ_CONCERN  | false                                             | Switch to use (or not) majority read concern                                                                       |
+| MONGODB_ENABLE_WRITE_CONCERN | true                                              | Switch to use (or not) majority write concern                                                                      |
+| MONGODB_CONNECT_TIMEOUT      | 5s                                                | The timeout when connecting to MongoDB (`time.Duration` format)                                                    |
+| MONGODB_QUERY_TIMEOUT        | 15s                                               | The timeout for querying MongoDB (`time.Duration` format)                                                          |
+| MONGODB_IS_SSL               | false                                             | Switch to use (or not) TLS when connecting to mongodb                                                              |
+| ZEBEDEE_URL                  | http://localhost:8082                             | The URL to Zebedee (for authentication)                                                                            |
+| ENABLE_PRIVATE_ENDPOINTS     | false                                             | Enable private endpoints for the API                                                                               |
+| ENABLE_PERMISSIONS_AUTHZ     | false                                             | Enable/disable user/service permissions checking for private endpoints                                             |
 
 ## Environments
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,9 @@ To run the Topic API locally requires the following:
 * No further dependencies other than those defined in `go.mod`. However, although by default the Topic API has the ENABLE_PRIVATE_ENDPOINTS environment variable set to false, note that it is commonly set to true locally (in the .zshrc - for use in the dp-compose stacks) so it may need to be explicitly set to false:
 
 ```shell
-ENABLE_PRIVATE_ENDPOINTS=false
+export ENABLE_PRIVATE_ENDPOINTS=false
 ```
-or otherwise AWS Cognito authorisation will be needed, as follows: 
-Run the [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/auth#auth-stack) and then log into your local Florence using your sandbox Florence credentials.
+Otherwise, AWS Cognito authorisation will be needed, e.g. run [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/auth#auth-stack) and then log into your local Florence using your sandbox Florence credentials.
 
 To run `make validate-specification`, which can be used to validate the swagger spec, you require Node v20.x and to install @redocly/cli:
 

--- a/README.md
+++ b/README.md
@@ -8,17 +8,19 @@ Enables greater flexibility in creating journeys through the website
 
 ### Dependencies
 
-The follow dependencies can all be met by running the Auth stack and then logging into your local Florence using your sandbox Florence credentials:
-* Zebedee
-* Mongo db
-* Florence authentication (AWS cognito)
+To run the Topic API locally requires the following:
 
-NB. Use [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/auth#auth-stack) to run these services, and the other Auth services, in local Docker containers.
-
+* Mongo db (you can use [dp-compose](https://github.com/ONSdigital/dp-compose) to stand up an instance in a local Docker container)
 * Once you have a working mongo db instance, you will want to populate your database with topics - see `./scripts/README.md` for seeding scripts
-* No further dependencies other than those defined in `go.mod`
+* No further dependencies other than those defined in `go.mod`. However, although by default the Topic API has the ENABLE_PRIVATE_ENDPOINTS environment variable set to false, note that it is commonly set to true locally (in the .zshrc - for use in the dp-compose stacks) so it may need to be explicitly set to false:
 
-To run make validate-specification you require Node v20.x and to install @redocly/cli:
+```shell
+ENABLE_PRIVATE_ENDPOINTS=false
+```
+or otherwise AWS Cognito authorisation will be needed, as follows: 
+Run the [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/auth#auth-stack) and then log into your local Florence using your sandbox Florence credentials.
+
+To run `make validate-specification`, which can be used to validate the swagger spec, you require Node v20.x and to install @redocly/cli:
 
 ```sh
    npm install -g @redocly/cli

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The follow dependencies can all be met by running the Auth stack and then loggin
 * Mongo db
 * Florence authentication (AWS cognito)
 
-NB. Use [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/v2/stacks/auth) to run these services in Docker containers.
+NB. Use [the auth stack in dp-compose](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/auth#auth-stack) to run these services, and the other Auth services, in local Docker containers.
 
 * Once you have a working mongo db instance, you will want to populate your database with topics - see `./scripts/README.md` for seeding scripts
 * No further dependencies other than those defined in `go.mod`


### PR DESCRIPTION
### What

When trying to run the Topic API locally I found that it had more dependencies than were listed in the README. So I've added these to the instructions.

### How to review

Sense check and/or run the Topic API locally, following the new instructions, and check that you can get a list of Topics by going to: http://localhost:25300/topics

### Who can review

Anyone but me.
